### PR TITLE
fix: replace deprecated include

### DIFF
--- a/roles/apt-gem-stuff/tasks/main.yml
+++ b/roles/apt-gem-stuff/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: apt-stuff.yml
-- include: gem-tools.yml
+- import_tasks: apt-stuff.yml
+- import_tasks: gem-tools.yml

--- a/roles/configure-logging/tasks/main.yml
+++ b/roles/configure-logging/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: "ufw.yml"
-- include: "auditd.yml"
+- import_tasks: "ufw.yml"
+- import_tasks: "auditd.yml"

--- a/roles/configure-system/tasks/main.yml
+++ b/roles/configure-system/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: "configure-sudoers.yml"
+- import_tasks: "configure-sudoers.yml"

--- a/roles/customize-browser/tasks/main.yml
+++ b/roles/customize-browser/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 # - include: "burp.yml"
-- include: "firefox.yml"
+- import_tasks: "firefox.yml"

--- a/roles/install-tools/tasks/main.yml
+++ b/roles/install-tools/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: apt-stuff.yml
-- include: gem-tools.yml
+- import_tasks: apt-stuff.yml
+- import_tasks: gem-tools.yml


### PR DESCRIPTION
This PR replaces all deprecated Ansible `- include:` directives with `- import_tasks:` to ensure compatibility with newer Ansible versions.

Command used:
```find . -type f -name "*.yml" -exec sed -i 's/^[[:space:]]*- include:/- import_tasks:/g' {} +```

Note: Please manually review any `when:` conditions if present, as `import_tasks` is not conditional-friendly.

Let me know if further adjustments are needed!
