### PR TITLE
Add ignore errors to all tasks

### DIFF
--- a/playbooks/android.yml
+++ b/playbooks/android.yml
@@ -1,4 +1,5 @@
 - name: Setup Android tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/api.yml
+++ b/playbooks/api.yml
@@ -1,4 +1,5 @@
 - name: Setup API tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/apt-gem-stuff.yml
+++ b/playbooks/apt-gem-stuff.yml
@@ -1,4 +1,5 @@
 - name: Setup apt & gem tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/cms_scanner.yml
+++ b/playbooks/cms_scanner.yml
@@ -1,4 +1,5 @@
 - name: Setup cms scanner tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/content_discovery.yml
+++ b/playbooks/content_discovery.yml
@@ -1,4 +1,5 @@
 - name: Setup content discovery tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/directory_fuzzers.yml
+++ b/playbooks/directory_fuzzers.yml
@@ -1,4 +1,5 @@
 - name: Setup directory fuzzers
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/dns_resolver.yml
+++ b/playbooks/dns_resolver.yml
@@ -1,4 +1,5 @@
 - name: Setup dns resolver tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/exploitation.yml
+++ b/playbooks/exploitation.yml
@@ -1,4 +1,5 @@
 - name: Setup exploitation tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/frameworks.yml
+++ b/playbooks/frameworks.yml
@@ -1,4 +1,5 @@
 - name: Setup frameworks tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/git_hunting.yml
+++ b/playbooks/git_hunting.yml
@@ -1,4 +1,5 @@
 - name: Setup git hunting tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/http_parameter.yml
+++ b/playbooks/http_parameter.yml
@@ -1,4 +1,5 @@
 - name: Setup http parameter tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/http_probe.yml
+++ b/playbooks/http_probe.yml
@@ -1,4 +1,5 @@
 - name: Setup Http_probe fuzzers
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/inspecting_js.yml
+++ b/playbooks/inspecting_js.yml
@@ -1,4 +1,5 @@
 - name: Setup JavaScript inspection tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/js_hunting.yml
+++ b/playbooks/js_hunting.yml
@@ -1,4 +1,5 @@
 - name: Setup js hunting tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/lfi_tools.yml
+++ b/playbooks/lfi_tools.yml
@@ -1,4 +1,5 @@
 - name: Setup lfi tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -1,4 +1,5 @@
 - name: Install all tools
+  ignore_errors: yes
   hosts: local
   become: yes
   roles:

--- a/playbooks/netword_scanner.yml
+++ b/playbooks/netword_scanner.yml
@@ -1,4 +1,5 @@
 - name: Setup network_scanner tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/open_redirect.yml
+++ b/playbooks/open_redirect.yml
@@ -1,4 +1,5 @@
 - name: Setup open redirection tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/request_smuggling.yml
+++ b/playbooks/request_smuggling.yml
@@ -1,4 +1,5 @@
 - name: Setup Request-Smuggling tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/sensitive_finding.yml
+++ b/playbooks/sensitive_finding.yml
@@ -1,4 +1,5 @@
 - name: Setup sensitive finding tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/sql_tools.yml
+++ b/playbooks/sql_tools.yml
@@ -1,4 +1,5 @@
 - name: Setup Sql tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/ssti_tools.yml
+++ b/playbooks/ssti_tools.yml
@@ -1,4 +1,5 @@
 - name: Setup ssti tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/subdomain_enum.yml
+++ b/playbooks/subdomain_enum.yml
@@ -1,4 +1,5 @@
 - name: Setup subdomain enumeration tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/visual_tools.yml
+++ b/playbooks/visual_tools.yml
@@ -1,4 +1,5 @@
 - name: Setup Visual tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/vulns_scanner.yml
+++ b/playbooks/vulns_scanner.yml
@@ -1,4 +1,5 @@
 - name: Setup vulns scanner tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/web_crawling.yml
+++ b/playbooks/web_crawling.yml
@@ -1,4 +1,5 @@
 - name: Setup Web Crawling tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/web_technologies.yml
+++ b/playbooks/web_technologies.yml
@@ -1,4 +1,5 @@
 - name: Setup web technologies tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/wordlists.yml
+++ b/playbooks/wordlists.yml
@@ -1,4 +1,5 @@
 - name: Setup wordlists tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/playbooks/xss_tools.yml
+++ b/playbooks/xss_tools.yml
@@ -1,4 +1,5 @@
 - name: Setup xss tools
+  ignore_errors: yes
   hosts: localhost
   become: yes
   roles:

--- a/roles/android/tasks/main.yml
+++ b/roles/android/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Install pip packages
+  ignore_errors: yes
   pip:
     name: "{{ item }}"
     state: latest
@@ -11,6 +12,7 @@
     - dnspy
 
 - name: Install required packages
+  ignore_errors: yes
   apt:
     name: "{{ item }}"
     state: latest
@@ -30,31 +32,37 @@
     - wkhtmltopdf
 
 - name: Clone Mobile-Security-Framework-MobSF from GitHub
+  ignore_errors: yes
   git:
     repo: https://github.com/MobSF/Mobile-Security-Framework-MobSF.git
     dest: /opt/Mobile-Security-Framework-MobSF
 
 - name: Run setup.sh
+  ignore_errors: yes
   command:
     cmd: ./setup.sh
     chdir: /opt/Mobile-Security-Framework-MobSF
 
 - name: Install python2.7
+  ignore_errors: yes
   apt:
     name: python2.7
     state: latest
 
 - name: Download get-pip.py for Python 2.7
+  ignore_errors: yes
   get_url:
     url: https://bootstrap.pypa.io/pip/2.7/get-pip.py
     dest: /usr/lib/python2.7/get-pip.py
 
 - name: Install pip for Python 2.7
+  ignore_errors: yes
   command:
     cmd: python2.7 get-pip.py
     chdir: /usr/lib/python2.7
 
 - name: Install prerequisites for Drozer
+  ignore_errors: yes
   command:
     cmd: pip2.7 install "{{ item }}"
   loop:
@@ -63,15 +71,18 @@
     - protobuf
 
 - name: Download Drozer wheel file
+  ignore_errors: yes
   get_url:
     url: https://github.com/FSecureLABS/drozer/releases/download/2.4.4/drozer-2.4.4-py2-none-any.whl
     dest: /tmp/drozer-2.4.4-py2-none-any.whl
 
 - name: Install Drozer
+  ignore_errors: yes
   command:
     cmd: pip2.7 install /tmp/drozer-2.4.4-py2-none-any.whl
 
 - name: Install additional tools
+  ignore_errors: yes
   apt:
     name: "{{ item }}"
     state: latest
@@ -87,6 +98,7 @@
     - jadx-dex2jar
 
 - name: Install OpenJDK headless for jarsigner
+  ignore_errors: yes
   apt:
     name: openjdk-11-jdk-headless
     state: latest

--- a/roles/api/tasks/main.yml
+++ b/roles/api/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure necessary directories exist
+  ignore_errors: yes
   file:
     path: "{{ item }}"
     state: directory
@@ -9,34 +10,40 @@
     - "/opt/tools/api/kiterunner-wordlists"
 
 - name: Download latest Kiterunner release version
+  ignore_errors: yes
   uri:
     url: "https://api.github.com/repos/assetnote/kiterunner/releases/latest"
     return_content: yes
   register: kiterunner_release
 
 - name: Set Kiterunner version and download URL
+  ignore_errors: yes
   set_fact:
     kiterunner_version: "{{ kiterunner_release.json.tag_name }}"
     kiterunner_url: "https://github.com/assetnote/kiterunner/releases/download/{{ kiterunner_version }}/kiterunner_{{ kiterunner_version }}_linux_amd64.tar.gz"
 
 - name: Download Kiterunner
+  ignore_errors: yes
   get_url:
     url: "{{ kiterunner_url }}"
     dest: "/opt/tools/api/kiterunner_{{ kiterunner_version }}_linux_amd64.tar.gz"
 
 - name: Extract Kiterunner
+  ignore_errors: yes
   unarchive:
     src: "/opt/tools/api/kiterunner_{{ kiterunner_version }}_linux_amd64.tar.gz"
     dest: "/opt/tools/api/kiterunner"
     remote_src: yes
 
 - name: Copy Kiterunner binary to /usr/local/bin
+  ignore_errors: yes
   copy:
     src: "/opt/tools/api/kiterunner/kr"
     dest: "/usr/local/bin/kr"
     mode: "0755"
 
 - name: Download and extract Kiterunner wordlists
+  ignore_errors: yes
   shell: |
     cd /opt/tools/api/kiterunner-wordlists
     wget https://wordlists-cdn.assetnote.io/data/kiterunner/routes-small.kite.tar.gz -q

--- a/roles/apt-gem-stuff/tasks/apt-stuff.yml
+++ b/roles/apt-gem-stuff/tasks/apt-stuff.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Updating apt repo/cache"
+  ignore_errors: yes
   become: yes
   apt:
     update_cache: yes
@@ -7,12 +8,14 @@
     cache_valid_time: 3600
 
 - name: "Upgrade all packages"
+  ignore_errors: yes
   apt:
     upgrade: yes
     force_apt_get: yes
   become: yes
 
 - name: "Installing Packages"
+  ignore_errors: yes
   become: yes
   apt:
     name:
@@ -53,6 +56,7 @@
     state: latest
 
 - name: Create tools directory
+  ignore_errors: yes
   file:
     path: /opt/tools
     state: directory

--- a/roles/apt-gem-stuff/tasks/gem-tools.yml
+++ b/roles/apt-gem-stuff/tasks/gem-tools.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Installing tools from Gems"
+  ignore_errors: yes
   gem:
     name: "{{ item }}"
     state: latest

--- a/roles/apt-gem-stuff/tasks/github-repos.yml
+++ b/roles/apt-gem-stuff/tasks/github-repos.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Installing useful github repos"
+  ignore_errors: yes
   git:
     repo: "{{ item.repo }}"
     dest: "{{ item.location }}"
@@ -10,11 +11,13 @@
   become_method: sudo
 
 - name: Create temporary build directory
+  ignore_errors: yes
   ansible.builtin.tempfile:
     state: directory
   register: build_dir
 
 - name: "Copying python script to download github releases"
+  ignore_errors: yes
   copy:
     src: "files/githubdownload.py"
     dest: "{{ build_dir.path }}/githubdownload.py"
@@ -25,6 +28,7 @@
   become_method: sudo
 
 - name: "Downloading github releases"
+  ignore_errors: yes
   shell: "{{ build_dir.path }}/githubdownload.py {{ item.repo }} {{ item.regex }} {{ item.location }} {% if item.filename is defined %}{{ item.filename }}{% endif %}"
   loop:
     - { repo: "jpillora/chisel",  regex: "_linux_amd64.gz", location: "/opt/chisel" }
@@ -40,6 +44,7 @@
   become_method: sudo
 
 - name: Remove temporary build directory
+  ignore_errors: yes
   ansible.builtin.file:
     path: "{{ build_dir.path }}"
     state: absent

--- a/roles/apt-gem-stuff/tasks/kerbrute.yml
+++ b/roles/apt-gem-stuff/tasks/kerbrute.yml
@@ -1,4 +1,5 @@
 ---
 - name: "install Kerbrute"
+  ignore_errors: yes
   shell: go install github.com/ropnop/kerbrute@master
 

--- a/roles/apt-gem-stuff/tasks/main.yml
+++ b/roles/apt-gem-stuff/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: apt-stuff.yml
-- include: gem-tools.yml
+- import_tasks: apt-stuff.yml
+- import_tasks: gem-tools.yml

--- a/roles/apt-gem-stuff/tasks/python-tools.yml
+++ b/roles/apt-gem-stuff/tasks/python-tools.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Install pipx tools"
+  ignore_errors: yes
   community.general.pipx:
     name: "{{ item.name }}"
     source: "{{ item.url }}"

--- a/roles/cms_scanner/tasks/main.yml
+++ b/roles/cms_scanner/tasks/main.yml
@@ -1,40 +1,48 @@
 - name: Ensure cms_scanner directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/cms_scanner"
     state: directory
   become: yes
 
 - name: Install Droopescan
+  ignore_errors: yes
   shell: "pip3 install droopescan --break-system-packages"
   become: yes
 
 - name: Download latest Nrich
+  ignore_errors: yes
   become: yes
   shell: |
     LATEST_NRICH=$(curl -s https://gitlab.com/api/v4/projects/33695681/releases | jq -r '.[0].assets.links[0].url')
     wget $LATEST_NRICH -O /tmp/nrich_latest_amd64.deb
 
 - name: Install Nrich
+  ignore_errors: yes
   shell: dpkg -i /tmp/nrich_latest_amd64.deb
   become: yes
 
 - name: Install AEM-Hacking using git
+  ignore_errors: yes
   git:
     repo: 'https://github.com/0ang3el/aem-hacker.git'
     dest: /opt/tools/cms_scanner/aem-hacker
   become: yes
 
 - name: Install requirements for AEM-Hacking
+  ignore_errors: yes
   shell: "pip3 install -r /opt/tools/cms_scanner/aem-hacker/requirements.txt --break-system-packages"
   become: yes
 
 - name: Install WhatWaf using git
+  ignore_errors: yes
   git:
     repo: 'https://github.com/Ekultek/WhatWaf.git'
     dest: /opt/tools/cms_scanner/WhatWaf
   become: yes
 
 - name: Copy WhatWaf binary to /usr/local/bin
+  ignore_errors: yes
   copy:
     src: "/opt/tools/cms_scanner/WhatWaf/whatwaf"
     dest: "/usr/local/bin/whatwaf"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,10 +1,12 @@
 - name: Update and upgrade apt packages
+  ignore_errors: yes
   apt:
     update_cache: yes
     upgrade: dist
   become: yes
 
 - name: Install common dependencies
+  ignore_errors: yes
   apt:
     name: "{{ item }}"
     state: present
@@ -42,6 +44,7 @@
   become: yes
 
 - name: Create tools directory
+  ignore_errors: yes
   file:
     path: /opt/tools
     state: directory

--- a/roles/configure-logging/tasks/auditd.yml
+++ b/roles/configure-logging/tasks/auditd.yml
@@ -1,4 +1,5 @@
 - name: "Install Packages"
+  ignore_errors: yes
   package:
     name: "auditd"
     state: present  
@@ -6,6 +7,7 @@
   become_method: sudo
 
 - name: "Configure Audit Rules"
+  ignore_errors: yes
   copy:
     src: audit.rules
     dest: /etc/audit/rules.d/audit.rules
@@ -16,6 +18,7 @@
   become_method: sudo
 
 - name: "Create _laurel user"
+  ignore_errors: yes
   user:
     name: _laurel
     state: present
@@ -26,6 +29,7 @@
   become_method: sudo
 
 - name: "Create directories for _laurel /var/log/laurel"
+  ignore_errors: yes
   file:
     path: "{{ item.path }}"
     state: directory
@@ -42,6 +46,7 @@
   poll: 0
 
 - name: "Copy laurel/config.toml to /etc/laurel/config.toml"
+  ignore_errors: yes
   copy:
     src: laurel/config.toml
     dest: /etc/laurel/config.toml
@@ -52,6 +57,7 @@
   become_method: sudo
 
 - name: "Copy laurel/laurel.conf to /etc/audit/plugins.d"
+  ignore_errors: yes
   copy:
     src: laurel/laurel.conf
     dest: /etc/audit/plugins.d/laurel.conf
@@ -62,12 +68,14 @@
   become_method: sudo
 
 - name: "Downloading https://github.com/threathunters-io/laurel/releases/download/v0.5.2/laurel-v0.5.2-x86_64-glibc.tar.gz"
+  ignore_errors: yes
   get_url:
     url: https://github.com/threathunters-io/laurel/releases/download/v0.5.2/laurel-v0.5.2-x86_64-glibc.tar.gz
     dest: /tmp/laurel-v0.5.2-x86_64-glibc.tar.gz
     mode: 0640
 
 - name: "Extract /tmp/laurel-v0.5.2-x86_64-glibc.tar.gz"
+  ignore_errors: yes
   unarchive:
     src: /tmp/laurel-v0.5.2-x86_64-glibc.tar.gz
     dest: /tmp/laurel/        
@@ -78,6 +86,7 @@
   become_method: sudo
 
 - name: "Running install -m755 laurel /usr/local/sbin/laurel"
+  ignore_errors: yes
   command: "install -m755 laurel /usr/local/sbin/laurel"
   args:
     chdir: /tmp/laurel/
@@ -85,6 +94,7 @@
   become_method: sudo
   
 - name: "Restart auditd"
+  ignore_errors: yes
   service:
     name: auditd
     state: restarted

--- a/roles/configure-logging/tasks/main.yml
+++ b/roles/configure-logging/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: "ufw.yml"
-- include: "auditd.yml"
+- import_tasks: "ufw.yml"
+- import_tasks: "auditd.yml"

--- a/roles/configure-logging/tasks/ufw.yml
+++ b/roles/configure-logging/tasks/ufw.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Enable rsyslog service"
+  ignore_errors: yes
   service:
     name: rsyslog
     enabled: yes
@@ -8,6 +9,7 @@
   become_method: sudo
 
 - name: "Configure UFW"
+  ignore_errors: yes
   ufw:
     state: enabled
     policy: allow
@@ -15,6 +17,7 @@
   become_method: sudo
 
 - name: "Log SYN packets in INPUT Chain"
+  ignore_errors: yes
   lineinfile:
     path: /etc/ufw/after.rules
     line: '-A ufw-after-input -p tcp --syn -j LOG --log-prefix "[UFW-SYN-LOG] "'
@@ -23,6 +26,7 @@
   become_method: sudo
   
 - name: "Restart ufw"
+  ignore_errors: yes
   service:
     name: ufw
     state: restarted

--- a/roles/configure-system/tasks/configure-sudoers.yml
+++ b/roles/configure-system/tasks/configure-sudoers.yml
@@ -1,5 +1,6 @@
 ---
 - name: Add NOPASSWD rule for the current user
+  ignore_errors: yes
   become: true
   lineinfile:
     dest: /etc/sudoers

--- a/roles/configure-system/tasks/main.yml
+++ b/roles/configure-system/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: "configure-sudoers.yml"
+- import_tasks: "configure-sudoers.yml"

--- a/roles/configure-tmux/tasks/main.yml
+++ b/roles/configure-tmux/tasks/main.yml
@@ -1,29 +1,34 @@
 ---
 - name: "Install Tmux"
+  ignore_errors: yes
   apt:
     name: tmux
     state: present
   become: true
   become_method: sudo
 - name: "Copying Tmux Config"
+  ignore_errors: yes
   copy:
     src: "{{ role_path }}/files/.tmux.conf"
     dest: "{{ ansible_env.HOME }}"
 
 
 - name: "Install Vim"
+  ignore_errors: yes
   apt:
     name: vim 
     state: present
   become: true
   become_method: sudo
 - name: "Copying Vim Config"
+  ignore_errors: yes
   copy:
     src: "{{ role_path }}/files/.vimrc"
     dest: "{{ ansible_env.HOME }}"
 
 
 - name: Vundle Clone
+  ignore_errors: yes
   git:
     repo: 'https://github.com/VundleVim/Vundle.vim.git'
     dest: "{{ ansible_env.HOME }}/.vim/bundle/Vundle.vim"
@@ -31,6 +36,7 @@
   become_user: "{{ ansible_user_id }}"
 
 - name: Install Vim Plugins
+  ignore_errors: yes
   command: vim +PluginInstall +qall
   become: yes
   become_user: "{{ ansible_user_id }}"

--- a/roles/content_discovery/tasks/main.yml
+++ b/roles/content_discovery/tasks/main.yml
@@ -1,9 +1,11 @@
 - name: Install dirsearch
+  ignore_errors: yes
   git:
     repo: 'https://github.com/maurosoria/dirsearch.git'
     dest: /opt/tools/content_discovery/dirsearch
 
 - name: Install gobuster and dirb
+  ignore_errors: yes
   apt:
     name: 
       - gobuster
@@ -11,6 +13,7 @@
     state: present
 
 - name: Install ffuf
+  ignore_errors: yes
   shell: go install github.com/ffuf/ffuf@latest
   environment:
     PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"

--- a/roles/customize-browser/tasks/burp.yml
+++ b/roles/customize-browser/tasks/burp.yml
@@ -1,9 +1,11 @@
 - name: "Check if BurpSuiteCA.der exists"
+  ignore_errors: yes
   stat:
     path: /usr/local/share/ca-certificates/BurpSuiteCA.der
   register: burp_cert
   
 - name: "Copying Burp Script"
+  ignore_errors: yes
   copy:
     src: files/getburpcert.sh
     dest: /tmp/getburpcert.sh
@@ -11,11 +13,13 @@
   when: burp_cert.stat.exists == False
 
 - name: "Executing bash script to Download CA Certificate"
+  ignore_errors: yes
   shell:
     /tmp/getburpcert.sh
   when: burp_cert.stat.exists == False
 
 - name: "Copying CA Certificate to /usr/local/share/ca-certificates"
+  ignore_errors: yes
   copy:
     src: /tmp/cacert.der
     dest: /usr/local/share/ca-certificates/BurpSuiteCA.der
@@ -27,6 +31,7 @@
   when: burp_cert.stat.exists == False
 
 - name: Create directory for Burp Suite extras
+  ignore_errors: yes
   ansible.builtin.file:
     path: "{{ burpsuite_extras_dir }}"
     state: directory
@@ -35,6 +40,7 @@
   become_method: sudo
 
 - name: Download jar files
+  ignore_errors: yes
   ansible.builtin.get_url:
     url: "{{ item.value.url }}"
     dest: "{{ burpsuite_extras_dir }}/{{ item.value.jar }}"
@@ -45,6 +51,7 @@
   loop: "{{ lookup('dict', burpsuite_extras_jars) }}"
   
 - name: Copy BurpSuite Community Config
+  ignore_errors: yes
   template:
     src: "templates/UserConfigCommunity.json.j2"
     dest: "/home/{{ ansible_user_id }}/.BurpSuite/UserConfigCommunity.json"

--- a/roles/customize-browser/tasks/firefox.yml
+++ b/roles/customize-browser/tasks/firefox.yml
@@ -1,4 +1,5 @@
 - name: "Updating Firefox Policies"
+  ignore_errors: yes
   template: 
     src: "templates/policies.json.j2"
     dest: "/usr/share/firefox-esr/distribution/policies.json"

--- a/roles/customize-browser/tasks/main.yml
+++ b/roles/customize-browser/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 # - include: "burp.yml"
-- include: "firefox.yml"
+- import_tasks: "firefox.yml"

--- a/roles/customize-terminal/tasks/main.yml
+++ b/roles/customize-terminal/tasks/main.yml
@@ -1,32 +1,38 @@
 ---
 - name: "Copy BashRC"
+  ignore_errors: yes
   copy:
     src: "{{ role_path }}/files/.bashrc"
     dest: "{{ ansible_env.HOME }}"
 
 - name: "Read current mate terminal profiles"
+  ignore_errors: yes
   dconf:
     key: "/org/mate/terminal/global/profile-list"
     state: "read"
   register: "profile_list"
 
 - name: "profile_list was not set, setting"
+  ignore_errors: yes
   set_fact:
     profile_list: 
       value: '["default"]'
   when: profile_list.value is none
 
 - name: "Adding our profile"
+  ignore_errors: yes
   set_fact:
     new_profile_list: "{{ profile_list.value | regex_replace(']$', \", 'video']\") }}"
 
 - name: "Writing updated profile list"
+  ignore_errors: yes
   dconf:
     key: "/org/mate/terminal/global/profile-list"
     value: "{{ new_profile_list }}"
   when: "'video' not in profile_list.value"
   
 - name: "Restoring Video Profile from Dump"
+  ignore_errors: yes
   shell:
     cmd: "dconf load /org/mate/terminal/profiles/video/ < {{ role_path }}/files/dconf-dump-video"
   when: "'video' not in profile_list.value"

--- a/roles/directory_fuzzers/tasks/main.yml
+++ b/roles/directory_fuzzers/tasks/main.yml
@@ -1,10 +1,12 @@
 - name: Install dirbuster
+  ignore_errors: yes
   apt:
     name: dirbuster
     state: present
   become: yes
 
 - name: Install ffuf
+  ignore_errors: yes
   command: "/usr/local/go/bin/go install github.com/ffuf/ffuf@latest"
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
@@ -13,6 +15,7 @@
   become: yes
 
 - name: Copy ffuf binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: /root/go/bin/ffuf
@@ -20,6 +23,7 @@
     mode: '0755'
 
 - name: Install gobuster
+  ignore_errors: yes
   command: "/usr/local/go/bin/go install github.com/OJ/gobuster/v3@latest"
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
@@ -28,6 +32,7 @@
   become: yes
 
 - name: Copy gobuster binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "{{ ansible_env.HOME }}/go/bin/gobuster"
@@ -35,5 +40,6 @@
     mode: "0755"
 
 - name: Install feroxbuster
+  ignore_errors: yes
   shell: "curl -sL https://raw.githubusercontent.com/epi052/feroxbuster/main/install-nix.sh | bash -s $HOME/.local/bin"
   become: yes

--- a/roles/dns_resolver/tasks/main.yml
+++ b/roles/dns_resolver/tasks/main.yml
@@ -1,10 +1,12 @@
 - name: Ensure dns_resolver directory exists
+  ignore_errors: yes
   become: yes
   file:
     path: /opt/tools/dns_resolver
     state: directory
 
 - name: Install Go-based tools and move binaries
+  ignore_errors: yes
   become: yes
   vars:
     go_tools:
@@ -35,6 +37,7 @@
         label: "{{ item.name }}"
 
 - name: Install MassDNS
+  ignore_errors: yes
   become: yes
   block:
     - name: Clone MassDNS repository
@@ -52,6 +55,7 @@
         mode: '0755'
 
 - name: Install dnsvalidator
+  ignore_errors: yes
   become: yes
   block:
     - name: Clone dnsvalidator repository

--- a/roles/forensics-blue/tasks/main.yml
+++ b/roles/forensics-blue/tasks/main.yml
@@ -1,15 +1,18 @@
 ---
 - name: Include vars of blue_vars.yml file.
+  ignore_errors: yes
   include_vars:
     file: blue_vars.yml
 
 - name: Update all packages to latest version
+  ignore_errors: yes
   become: yes
   apt:
     update_cache: yes
     cache_valid_time: 86400
 
 - name: Install foremost, exiftool, steghide
+  ignore_errors: yes
   package:
     name: "{{ item }}"
     state: latest
@@ -17,6 +20,7 @@
   with_items: "{{ packages }}"
 
 - name: Clone forensic tools.
+  ignore_errors: yes
   git:
     repo: "{{ item }}"
     dest: "{{ blue_dir }}{{ item.split('/')[-1].replace('.git','') }}"
@@ -26,34 +30,40 @@
   become: yes
 
 - name: Install volatility 3 requirements
+  ignore_errors: yes
   pip:
     requirements: "{{ blue_dir }}{{ vol3_dir }}/requirements.txt"
 
 - name: Install olevba via pip for analyzing macros
+  ignore_errors: yes
   pip:
     name: "{{ item }}"
   with_items: "{{ pip_modules }}"
   become: yes
 
 - name: Download oledump
+  ignore_errors: yes
   get_url:
     url: "http://didierstevens.com/files/software/oledump_V{{ oledump_version }}.zip"
     dest: "{{ blue_dir }}"
     checksum: "{{ oledump_checksum }}"
 
 - name: Expand oledump
+  ignore_errors: yes
   unarchive:
     src: "{{ blue_dir }}oledump_V{{ oledump_version }}.zip"
     dest: "{{ oledump_dir }}"
     remote_src: yes
 
 - name: Removing oledump zip
+  ignore_errors: yes
   file:
     path: "{{ blue_dir }}oledump_V{{ oledump_version }}.zip"
     state: absent
   become: yes
 
 - name: Add forensic tools alias to .zshrc
+  ignore_errors: yes
   lineinfile:
     path: ~/.zshrc
     line: "{{ item }}"

--- a/roles/frameworks/tasks/main.yml
+++ b/roles/frameworks/tasks/main.yml
@@ -1,10 +1,12 @@
 - name: Install w3af
+  ignore_errors: yes
   git:
     repo: 'https://github.com/andresriancho/w3af.git'
     dest: /opt/tools/frameworks/w3af
   become: yes
 
 - name: Install Arachni
+  ignore_errors: yes
   shell: |
     gem install bundler && \
     gem install arachni

--- a/roles/git_hunting/tasks/main.yml
+++ b/roles/git_hunting/tasks/main.yml
@@ -1,10 +1,12 @@
 - name: Ensure git_hunting directory exists
+  ignore_errors: yes
   become: yes
   file:
     path: /opt/tools/git_hunting
     state: directory
 
 - name: Clone repositories and install requirements
+  ignore_errors: yes
   become: yes
   vars:
     git_tools:
@@ -34,5 +36,6 @@
         label: "{{ item.name }}"
 
 - name: Install GitHacker
+  ignore_errors: yes
   become: yes
   shell: "pip3 install GitHacker --break-system-packages"

--- a/roles/http_parameter/tasks/main.yml
+++ b/roles/http_parameter/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure http_parameter directories exist
+  ignore_errors: yes
   become: yes
   file:
     path: "{{ item }}"
@@ -8,10 +9,12 @@
     - /opt/tools/http_parameter/x8
 
 - name: Install Arjun
+  ignore_errors: yes
   become: yes
   shell: "pip3 install arjun --break-system-packages"
 
 - name: Download and copy x8
+  ignore_errors: yes
   become: yes
   block:
     - name: Download x8

--- a/roles/http_probe/tasks/main.yml
+++ b/roles/http_probe/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Install Go-based tools and copy binaries
+  ignore_errors: yes
   become: yes
   vars:
     go_tools:

--- a/roles/inspecting_js/tasks/main.yml
+++ b/roles/inspecting_js/tasks/main.yml
@@ -1,10 +1,12 @@
 - name: Ensure inspecting_js directory exists
+  ignore_errors: yes
   become: yes
   file:
     path: /opt/tools/inspecting_js
     state: directory
 
 - name: Install LinkFinder and JSParser
+  ignore_errors: yes
   become: yes
   block:
     - name: Clone LinkFinder repository

--- a/roles/install-tools/tasks/apt-stuff.yml
+++ b/roles/install-tools/tasks/apt-stuff.yml
@@ -1,15 +1,18 @@
 ---
 - name: "Updating apt repo/cache"
+  ignore_errors: yes
   apt: update_cache=yes force_apt_get=yes cache_valid_time=3600
   become: true
   become_method: sudo
 
 - name: "Upgrade all packages"
+  ignore_errors: yes
   apt: upgrade=yes force_apt_get=yes
   become: true
   become_method: sudo
   
 - name: "Installing Packages"
+  ignore_errors: yes
   package:
     name:
       - jq

--- a/roles/install-tools/tasks/gem-tools.yml
+++ b/roles/install-tools/tasks/gem-tools.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Installing tools from Gems"
+  ignore_errors: yes
   gem:
     name: "{{ item }}"
     state: latest

--- a/roles/install-tools/tasks/github-repos.yml
+++ b/roles/install-tools/tasks/github-repos.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Installing useful github repos"
+  ignore_errors: yes
   git:
     repo: "{{ item.repo }}"
     dest: "{{ item.location }}"
@@ -10,11 +11,13 @@
   become_method: sudo
 
 - name: Create temporary build directory
+  ignore_errors: yes
   ansible.builtin.tempfile:
     state: directory
   register: build_dir
 
 - name: "Copying python script to download github releases"
+  ignore_errors: yes
   copy:
     src: "files/githubdownload.py"
     dest: "{{ build_dir.path }}/githubdownload.py"
@@ -25,6 +28,7 @@
   become_method: sudo
 
 - name: "Downloading github releases"
+  ignore_errors: yes
   shell: "{{ build_dir.path }}/githubdownload.py {{ item.repo }} {{ item.regex }} {{ item.location }} {% if item.filename is defined %}{{ item.filename }}{% endif %}"
   loop:
     - { repo: "jpillora/chisel",  regex: "_linux_amd64.gz", location: "/opt/chisel" }
@@ -40,6 +44,7 @@
   become_method: sudo
 
 - name: Remove temporary build directory
+  ignore_errors: yes
   ansible.builtin.file:
     path: "{{ build_dir.path }}"
     state: absent

--- a/roles/install-tools/tasks/main.yml
+++ b/roles/install-tools/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: apt-stuff.yml
-- include: gem-tools.yml
+- import_tasks: apt-stuff.yml
+- import_tasks: gem-tools.yml

--- a/roles/js_hunting/tasks/main.yml
+++ b/roles/js_hunting/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Set tools
+  ignore_errors: yes
   set_fact:
     tools:
       - name: Getjs
@@ -16,12 +17,14 @@
         requirements: "bash install.sh"
 
 - name: Ensure js_hunting directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/js_hunting"
     state: directory
   become: yes
 
 - name: Install {{ item.name }}
+  ignore_errors: yes
   command: "{{ item.install | default(omit) }}"
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
@@ -32,6 +35,7 @@
   loop: "{{ tools }}"
 
 - name: Copy {{ item.name }} binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "{{ item.src | default(omit) }}"
@@ -41,6 +45,7 @@
   loop: "{{ tools }}"
 
 - name: Install {{ item.name }} using git
+  ignore_errors: yes
   git:
     repo: "{{ item.repo | default(omit) }}"
     dest: "/opt/tools/js_hunting/{{ item.name }}"
@@ -49,24 +54,28 @@
   loop: "{{ tools }}"
 
 - name: Install requirements for {{ item.name }}
+  ignore_errors: yes
   shell: "cd /opt/tools/js_hunting/{{ item.name }}/ && {{ item.requirements }}"
   become: yes
   when: item.requirements is defined
   loop: "{{ tools }}"
 
 - name: Download subjs
+  ignore_errors: yes
   become: yes
   get_url:
     url: "https://github.com/lc/subjs/releases/download/v1.0.1/subjs_1.0.1_linux_amd64.tar.gz"
     dest: "/tmp/subjs_1.0.1_linux_amd64.tar.gz"
 
 - name: Ensure subjs directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/js_hunting/subjs"
     state: directory
   become: yes
 
 - name: Extract subjs
+  ignore_errors: yes
   become: yes
   unarchive:
     src: "/tmp/subjs_1.0.1_linux_amd64.tar.gz"
@@ -74,6 +83,7 @@
     remote_src: yes
 
 - name: Copy subjs binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "/opt/tools/js_hunting/subjs/subjs"

--- a/roles/lfi_tools/tasks/main.yml
+++ b/roles/lfi_tools/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure lfi_tools directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/lfi_tools"
     state: directory
@@ -6,6 +7,7 @@
 
 
 - name: Install LFISuite using git
+  ignore_errors: yes
   git:
     repo: 'https://github.com/D35m0nd142/LFISuite.git'
     dest: /opt/tools/lfi_tools/LFISuite
@@ -13,6 +15,7 @@
 
 
 - name: Install mrco24-lfi
+  ignore_errors: yes
   command: "/usr/local/go/bin/go install github.com/mrco24/mrco24-lfi@latest"
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
@@ -21,6 +24,7 @@
   become: yes
 
 - name: Copy mrco24-lfi binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "{{ ansible_env.HOME }}/go/bin/mrco24-lfi"

--- a/roles/network_scanner/tasks/main.yml
+++ b/roles/network_scanner/tasks/main.yml
@@ -1,10 +1,12 @@
 - name: Ensure network_scanner directory exists
+  ignore_errors: yes
   become: yes
   file:
     path: /opt/tools/network_scanner
     state: directory
 
 - name: Install masscan and naabu
+  ignore_errors: yes
   become: yes
   block:
     - name: Install masscan using git
@@ -38,6 +40,7 @@
         mode: '0755'
 
 - name: Install unimap
+  ignore_errors: yes
   become: yes
   shell: |
     cd /usr/local/bin

--- a/roles/open_redirect/tasks/main.yml
+++ b/roles/open_redirect/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Install open-redirect
+  ignore_errors: yes
   command: "/usr/local/go/bin/go install github.com/mrco24/open-redirect@latest"
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
@@ -7,6 +8,7 @@
   become: yes
 
 - name: Copy open-redirect binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "{{ ansible_env.HOME }}/go/bin/open-redirect"

--- a/roles/pwn-windows/tasks/gem-tools.yml
+++ b/roles/pwn-windows/tasks/gem-tools.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Installing tools from Gems"
+  ignore_errors: yes
   gem:
     name: "{{ item }}"
     state: latest

--- a/roles/pwn-windows/tasks/main.yml
+++ b/roles/pwn-windows/tasks/main.yml
@@ -1,10 +1,12 @@
 - include_tasks: gem-tools.yml
 - name: Include vars of pwnwin_vars.yml file.
+  ignore_errors: yes
   include_vars:
     file: pwnwin_vars.yml
 
 
 - name: Cloning Windows Reference Material
+  ignore_errors: yes
   git:
     repo: "{{ item }}"
     dest: "/opt/windows/references/{{ item.split('/')[-1].replace('.git','')}}"
@@ -13,6 +15,7 @@
   become: yes
 
 - name: Downloading precompiled Packages
+  ignore_errors: yes
   get_url:
     url: "{{ item }}"
     dest: "/opt/windows/"
@@ -22,11 +25,13 @@
   become: yes
 
 - name: Create temporary build directory
+  ignore_errors: yes
   ansible.builtin.tempfile:
     state: directory
   register: build_dir
 
 - name: "Copying python script to download github releases"
+  ignore_errors: yes
   copy:
     src: "files/githubdownload.py"
     dest: "{{ build_dir.path }}/githubdownload.py"
@@ -37,6 +42,7 @@
   become_method: sudo
 
 - name: Ensure destination directories exist
+  ignore_errors: yes
   file:
     path: "{{ item.dest }}" # | dirname }}"
     state: directory
@@ -88,6 +94,7 @@
 
 
 - name: "Downloading github releases"
+  ignore_errors: yes
   shell: "{{ build_dir.path }}/githubdownload.py {{ item.repo }} {{ item.regex }} {{ item.location }} {% if item.filename is defined %}{{ item.filename }}{% endif %}"
   loop:
     - { repo: "jpillora/chisel",  regex: "_linux_amd64.gz", location: "/opt/windows/Persistence/chisel" }
@@ -102,6 +109,7 @@
   become_method: sudo
 
 - name: Install APT packages
+  ignore_errors: yes
   apt:
     name: "{{ item }}"
     state: present
@@ -117,19 +125,23 @@
   become: yes
 
 - name: Create a Python virtual environment
+  ignore_errors: yes
   command: python3 -m venv "{{ playbook_dir }}/venv"
   args:
     creates: "{{ playbook_dir }}/venv"
 
 - name: Ensure pip is installed in the virtual environment
+  ignore_errors: yes
   command: "{{ playbook_dir }}/venv/bin/python -m ensurepip"
   args:
     creates: "{{ playbook_dir }}/venv/bin/pip"
 
 - name: Upgrade pip in the virtual environment
+  ignore_errors: yes
   command: "{{ playbook_dir }}/venv/bin/pip install --upgrade pip"
 
 - name: Install PIP packages in a virtual environment
+  ignore_errors: yes
   command: pip install {{ item }} --break-system-packages 
   loop:
     - certipy-ad
@@ -138,6 +150,7 @@
 
 
 - name: Install packages
+  ignore_errors: yes
   ignore_errors: yes
   apt:
     name: "{{ item }}"
@@ -162,6 +175,7 @@
 
 
 - name: Clone repositories
+  ignore_errors: yes
   ignore_errors: yes
   git:
     repo: "{{ item.repo }}"
@@ -190,15 +204,18 @@
 
 - name: Install Adidnsdump 
   ignore_errors: yes
+  ignore_errors: yes
   shell: "pip install git+https://github.com/dirkjanm/adidnsdump#egg=adidnsdump --break-system-packages"
 
 - name: Install requirements for Spraykatz 
+  ignore_errors: yes
   ignore_errors: yes
   shell: "pip install -r {{ item }} --break-system-packages"
   loop:
     - /opt/windows/Spraykatz/requirements.txt
 
 - name: Install LDAPDomainDump
+  ignore_errors: yes
   shell: "pip install ldapdomaindump --break-system-packages"
   ignore_errors: yes
 
@@ -206,6 +223,7 @@
 
 
 - name: Download files
+  ignore_errors: yes
   ignore_errors: yes
   get_url:
     url: "{{ item.url }}"
@@ -534,24 +552,28 @@
 
 
 - name: Install PoshC2
+  ignore_errors: yes
   shell: curl -sSL https://raw.githubusercontent.com/nettitude/PoshC2/dev/Install.sh | sudo bash -s -- -b dev
   ignore_errors: yes
 
 
 
 - name: Ensure dot_exe directory exists
+  ignore_errors: yes
   file:
     path: /opt/windows/dot_exe
     state: directory
     mode: '0755'
 
 - name: Ensure dot_ps directory exists
+  ignore_errors: yes
   file:
     path: /opt/windows/dot_ps
     state: directory
     mode: '0755'
 
 - name: Find all .exe files in /opt/windows and its subdirectories
+  ignore_errors: yes
   find:
     paths: /opt/windows
     patterns: '*.exe'
@@ -559,10 +581,12 @@
   register: exe_files
 
 - name: Debug exe_files variable
+  ignore_errors: yes
   debug:
     var: exe_files
 
 - name: Copy all .exe files to dot_exe directory
+  ignore_errors: yes
   copy:
     src: "{{ item.path }}"
     dest: "/opt/windows/dot_exe/{{ item.path | basename }}"
@@ -571,6 +595,7 @@
   when: exe_files.matched > 0
 
 - name: Find all .ps1 files in /opt/windows and its subdirectories
+  ignore_errors: yes
   find:
     paths: /opt/windows
     patterns: '*.ps*1'
@@ -578,10 +603,12 @@
   register: ps1_files
 
 - name: Debug ps1_files variable
+  ignore_errors: yes
   debug:
     var: ps1_files
 
 - name: Copy all .exe files to dot_exe directory
+  ignore_errors: yes
   copy:
     src: "{{ item.path }}"
     dest: "/opt/windows/dot_ps/{{ item.path | basename }}"
@@ -593,10 +620,12 @@
 
 - name: "install Kerbrute"
   ignore_errors: yes
+  ignore_errors: yes
   shell:  go install github.com/ropnop/kerbrute@master
   become: true
 
 - name: "Copy kerbrute to /usr/local/bin"
+  ignore_errors: yes
   ignore_errors: yes
   shell: cp /root/go/bin/kerbrute /usr/local/bin/kerbrute
   become: true

--- a/roles/request_smuggling/tasks/main.yml
+++ b/roles/request_smuggling/tasks/main.yml
@@ -1,16 +1,19 @@
 - name: Ensure web_crawling directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/request_smuggling"
     state: directory
   become: yes
 
 - name: Install http-request-smuggling using git
+  ignore_errors: yes
   git:
     repo: 'https://github.com/anshumanpattnaik/http-request-smuggling.git'
     dest: /opt/tools/request_smuggling/http-request-smuggling
   become: yes
 
 - name: Install requirements for http-request-smuggling in virtual environment
+  ignore_errors: yes
   shell: "pip3 install -r /opt/tools/request_smuggling/http-request-smuggling/requirements.txt --break-system-packages"
   become: yes
 

--- a/roles/sensitive_finding/tasks/main.yml
+++ b/roles/sensitive_finding/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Set tools
+  ignore_errors: yes
   set_fact:
     tools:
       - name: EarlyBird
@@ -14,12 +15,14 @@
         dest: "/usr/local/bin/mantra"
 
 - name: Ensure sensitive_finding directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/sensitive_finding"
     state: directory
   become: yes
 
 - name: Clone {{ item.name }} repository
+  ignore_errors: yes
   git:
     repo: "{{ item.repo | default(omit) }}"
     dest: "/opt/tools/sensitive_finding/{{ item.name }}"
@@ -28,12 +31,14 @@
   loop: "{{ tools }}"
 
 - name: Build and install {{ item.name }}
+  ignore_errors: yes
   shell: "cd /opt/tools/sensitive_finding/{{ item.name }}/ && {{ item.build }}"
   become: yes
   when: item.build is defined
   loop: "{{ tools }}"
 
 - name: Install {{ item.name }}
+  ignore_errors: yes
   command: "{{ item.install | default(omit) }}"
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
@@ -44,6 +49,7 @@
   loop: "{{ tools }}"
 
 - name: Copy {{ item.name }} binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "{{ item.src | default(omit) }}"

--- a/roles/sql_tools/tasks/main.yml
+++ b/roles/sql_tools/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Set sql_tools
+  ignore_errors: yes
   set_fact:
     sql_tools:
       - name: Jeeves
@@ -18,12 +19,14 @@
         install: "cd /opt/tools/sql_tools/ghauri && python3 -m pip install --upgrade -r requirements.txt --break-system-packages && python3 setup.py install"
 
 - name: Ensure sql_tools directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/sql_tools"
     state: directory
   become: yes
 
 - name: Clone {{ item.name }} repository
+  ignore_errors: yes
   git:
     repo: "{{ item.repo | default(omit) }}"
     dest: "/opt/tools/sql_tools/{{ item.name }}"
@@ -32,6 +35,7 @@
   loop: "{{ sql_tools }}"
 
 - name: Install {{ item.name }}
+  ignore_errors: yes
   command: "{{ item.install | default(omit) }}"
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
@@ -42,6 +46,7 @@
   loop: "{{ sql_tools }}"
 
 - name: Copy {{ item.name }} binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "{{ item.src | default(omit) }}"

--- a/roles/ssrf_tools/tasks/main.yml
+++ b/roles/ssrf_tools/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Set ssrf_tools
+  ignore_errors: yes
   set_fact:
     ssrf_tools:
       - name: Interactsh
@@ -13,12 +14,14 @@
         install: "cd /opt/tools/ssrf_tools/Gopherus && chmod +x install.sh && ./install.sh"
 
 - name: Ensure ssrf_tools directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/ssrf_tools"
     state: directory
   become: yes
 
 - name: Clone {{ item.name }} repository
+  ignore_errors: yes
   git:
     repo: "{{ item.repo | default(omit) }}"
     dest: "/opt/tools/ssrf_tools/{{ item.name }}"
@@ -27,6 +30,7 @@
   loop: "{{ ssrf_tools }}"
 
 - name: Install {{ item.name }}
+  ignore_errors: yes
   command: "{{ item.install | default(omit) }}"
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
@@ -37,6 +41,7 @@
   loop: "{{ ssrf_tools }}"
 
 - name: Copy {{ item.name }} binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "{{ item.src | default(omit) }}"

--- a/roles/ssti_tools/tasks/main.yml
+++ b/roles/ssti_tools/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure ssti_tools directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/ssti_tools"
     state: directory
@@ -6,12 +7,14 @@
 
 
 - name: Install tplmap using git
+  ignore_errors: yes
   git:
     repo: 'https://github.com/epinna/tplmap.git'
     dest: /opt/tools/ssti_tools/tplmap
   become: yes
 
 - name: Install requirements for tplmap in virtual environment
+  ignore_errors: yes
   shell: "pip install -r /opt/tools/ssti_tools/tplmap/requirements.txt --break-system-packages"
   become: yes
   ignore_errors: yes

--- a/roles/subdomain_enum/tasks/main.yml
+++ b/roles/subdomain_enum/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Setup tools
+  ignore_errors: yes
   become: yes
   block:
     - name: Install tools using git

--- a/roles/useful_tools/tasks/main.yml
+++ b/roles/useful_tools/tasks/main.yml
@@ -1,9 +1,11 @@
 - name: Ensure useful_tools directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/useful_tools"
     state: directory
 
 - name: Install Go tools and copy binaries
+  ignore_errors: yes
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
     GOROOT: "/usr/local/go"
@@ -43,6 +45,7 @@
         - cf-check
 
 - name: Clone repositories
+  ignore_errors: yes
   block:
     - name: Clone SploitScan repository
       git:
@@ -60,7 +63,9 @@
         dest: /opt/tools/useful_tools/Interlace
 
 - name: Install requirements for Oralyzer
+  ignore_errors: yes
   shell: "cd /opt/tools/useful_tools/Oralyzer && pip3 install -r requirements.txt --break-system-packages"
 
 - name: Install Interlace
+  ignore_errors: yes
   shell: "cd /opt/tools/useful_tools/Interlace && python3 setup.py install"

--- a/roles/visual_tools/tasks/main.yml
+++ b/roles/visual_tools/tasks/main.yml
@@ -1,10 +1,12 @@
 - name: Ensure visual_tools directory exists
+  ignore_errors: yes
   ansible.builtin.file:
     path: "/opt/tools/visual_tools"
     state: directory
   become: yes
 
 - name: Install Gowitness
+  ignore_errors: yes
   ansible.builtin.command:
     cmd: "/usr/local/go/bin/go install github.com/sensepost/gowitness@latest"
   environment:
@@ -14,6 +16,7 @@
   become: yes
 
 - name: Copy Gowitness binary to /usr/local/bin
+  ignore_errors: yes
   ansible.builtin.copy:
     src: "{{ ansible_env.HOME }}/go/bin/gowitness"
     dest: "/usr/local/bin/gowitness"
@@ -21,18 +24,21 @@
   become: yes
 
 - name: Download Aquatone
+  ignore_errors: yes
   ansible.builtin.get_url:
     url: "https://github.com/michenriksen/aquatone/releases/download/v1.7.0/aquatone_linux_amd64_1.7.0.zip"
     dest: "/tmp/aquatone_linux_amd64_1.7.0.zip"
   become: yes
 
 - name: Ensure temporary directory for Aquatone exists
+  ignore_errors: yes
   ansible.builtin.file:
     path: "/tmp/aquatone"
     state: directory
   become: yes
 
 - name: Extract Aquatone
+  ignore_errors: yes
   ansible.builtin.unarchive:
     src: "/tmp/aquatone_linux_amd64_1.7.0.zip"
     dest: "/tmp/aquatone"
@@ -40,6 +46,7 @@
   become: yes
 
 - name: Copy Aquatone binary to /usr/local/bin
+  ignore_errors: yes
   ansible.builtin.copy:
     src: "/tmp/aquatone/aquatone"
     dest: "/usr/local/bin/aquatone"

--- a/roles/vulns_scanner/tasks/main.yml
+++ b/roles/vulns_scanner/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure directories exist
+  ignore_errors: yes
   become: yes
   file:
     path: "{{ item }}"
@@ -12,6 +13,7 @@
     - "/root/templates"
 
 - name: Install Afrog
+  ignore_errors: yes
   become: yes
   command: "/usr/local/go/bin/go install github.com/zan8in/afrog/v2/cmd/afrog@latest"
   environment:
@@ -20,6 +22,7 @@
     PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin:{{ ansible_env.HOME }}/go/bin"
 
 - name: Copy binaries to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "{{ item.src }}"
@@ -33,6 +36,7 @@
     - { src: "{{ ansible_env.HOME }}/go/bin/cent", dest: "cent" }
 
 - name: Install POC-bomber and requirements
+  ignore_errors: yes
   become: yes
   vars:
     dest_dir: "/opt/tools/vulns_scanner"
@@ -50,6 +54,7 @@
         extra_args: --ignore-installed --no-warn-script-location
 
 - name: Install and configure Xray
+  ignore_errors: yes
   become: yes
   tasks:
     - name: Fetch latest Xray release
@@ -94,6 +99,7 @@
         mv xray_linux_amd64 xray
 
 - name: Install Jaeles and templates
+  ignore_errors: yes
   become: yes
   tasks:
     - name: Fetch latest Jaeles release
@@ -124,6 +130,7 @@
         dest: "/root/templates/ghsec-jaeles-signatures"
 
 - name: Install Nuclei and templates
+  ignore_errors: yes
   become: yes
   tasks:
     - name: Fetch latest Nuclei release
@@ -149,6 +156,7 @@
         dest: "/root/templates/nuclei-templates"
 
 - name: Install Cent
+  ignore_errors: yes
   become: yes
   command: "/usr/local/go/bin/go install -v github.com/xm1k3/cent@latest"
   environment:
@@ -157,5 +165,6 @@
     PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin:{{ ansible_env.HOME }}/go/bin"
 
 - name: Cent init
+  ignore_errors: yes
   become: yes
   shell: "cent init"

--- a/roles/web_crawling/tasks/main.yml
+++ b/roles/web_crawling/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Set web_crawling_tools
+  ignore_errors: yes
   set_fact:
     web_crawling_tools:
       - name: Gospider
@@ -51,12 +52,14 @@
         build: "cd /opt/tools/web_crawling/freq/ && mv main.go freq.go && go build freq.go && cp freq /usr/bin"
 
 - name: Ensure web_crawling directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/web_crawling"
     state: directory
   become: yes
 
 - name: Clone {{ item.name }} repository
+  ignore_errors: yes
   git:
     repo: "{{ item.repo | default(omit) }}"
     dest: "{{ item.dest | default(omit) }}"
@@ -65,6 +68,7 @@
   loop: "{{ web_crawling_tools }}"
 
 - name: Install {{ item.name }}
+  ignore_errors: yes
   command: "{{ item.install | default(omit) }}"
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
@@ -75,6 +79,7 @@
   loop: "{{ web_crawling_tools }}"
 
 - name: Copy {{ item.name }} binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "{{ item.src | default(omit) }}"
@@ -84,12 +89,14 @@
   loop: "{{ web_crawling_tools }}"
 
 - name: Install requirements for {{ item.name }}
+  ignore_errors: yes
   shell: "pip3 install -r {{ item.requirements }} --break-system-packages"
   become: yes
   when: item.requirements is defined
   loop: "{{ web_crawling_tools }}"
 
 - name: Build {{ item.name }}
+  ignore_errors: yes
   shell: "{{ item.build | default(omit) }}"
   become: yes
   when: item.build is defined

--- a/roles/web_technologies/tasks/main.yml
+++ b/roles/web_technologies/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Ensure web_technologies directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/web_technologies"
     state: directory
@@ -6,6 +7,7 @@
 
 
 - name: Install wappalyzer-cli
+  ignore_errors: yes
   shell: |
     cd /opt/tools/web_technologies &&
     git clone https://github.com/gokulapap/wappalyzer-cli &&

--- a/roles/wordlists/tasks/main.yml
+++ b/roles/wordlists/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Install SecLists
+  ignore_errors: yes
   git:
     repo: 'https://github.com/danielmiessler/SecLists.git'
     dest: /opt/tools/wordlists/SecLists

--- a/roles/xss_tools/tasks/main.yml
+++ b/roles/xss_tools/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Set xss_tools
+  ignore_errors: yes
   set_fact:
     xss_tools:
       - name: Dalfox
@@ -31,12 +32,14 @@
         requirements: "/opt/tools/xss_tools/xss_vibes/requirements"
 
 - name: Ensure xss_tools directory exists
+  ignore_errors: yes
   file:
     path: "/opt/tools/xss_tools"
     state: directory
   become: yes
 
 - name: Clone {{ item.name }} repository
+  ignore_errors: yes
   git:
     repo: "{{ item.repo | default(omit) }}"
     dest: "{{ item.dest | default(omit) }}"
@@ -45,6 +48,7 @@
   loop: "{{ xss_tools }}"
 
 - name: Install {{ item.name }}
+  ignore_errors: yes
   command: "{{ item.install | default(omit) }}"
   environment:
     GOPATH: "{{ ansible_env.HOME }}/go"
@@ -55,6 +59,7 @@
   loop: "{{ xss_tools }}"
 
 - name: Copy {{ item.name }} binary to /usr/local/bin
+  ignore_errors: yes
   become: yes
   copy:
     src: "{{ item.src | default(omit) }}"
@@ -64,6 +69,7 @@
   loop: "{{ xss_tools }}"
 
 - name: Install requirements for {{ item.name }}
+  ignore_errors: yes
   shell: "pip3 install -r {{ item.requirements }} --break-system-packages"
   become: yes
   when: item.requirements is defined


### PR DESCRIPTION
### Summary

This pull request adds `ignore_errors: yes` to every task across all Ansible playbooks to ensure that the execution continues even if a particular task fails. This is especially helpful when optional tools or packages are not available or specific versions can't be fetched.

### Changes Made

- Used a one-liner command to append `ignore_errors: yes` after every `- name:` line in all `.yml` files.

```bash
find . -name "*.yml" -exec sed -i '/^- name:/a\  ignore_errors: yes' {} +
