### PR TITLE
Add pip configuration role to support break-system-packages

### DIFF
--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -2,6 +2,8 @@
   hosts: local
   become: yes
   roles:
+    - role: "set-pip-config"
+      tags: config 
     - role: "roles/install-tools"
       tags: config
     - role: "roles/configure-tmux"

--- a/roles/set-pip-config/tasks/main.yml
+++ b/roles/set-pip-config/tasks/main.yml
@@ -1,0 +1,18 @@
+- name: Set global pip config to always break system packages
+  copy:
+    dest: /etc/pip.conf.d/system-break.conf
+    content: |
+      [install]
+      break-system-packages = true
+  become: yes
+
+- name: Verify pip config file
+  stat:
+    path: /etc/pip.conf.d/system-break.conf
+  register: pip_conf_stat
+  become: yes
+
+- name: Debug pip config presence
+  debug:
+    msg: "Pip config exists at {{ pip_conf_stat.stat.path }} with size {{ pip_conf_stat.stat.size }} bytes"
+  when: pip_conf_stat.stat.exists

--- a/roles/set-pip-config/tasks/main.yml
+++ b/roles/set-pip-config/tasks/main.yml
@@ -4,6 +4,9 @@
     content: |
       [install]
       break-system-packages = true
+    owner: root
+    group: root
+    mode: '0644'      
   become: yes
 
 - name: Verify pip config file


### PR DESCRIPTION
This pull request adds a new Ansible role called `set-pip-config` to configure pip globally with the `break-system-packages` option.

### Changes:
- Added a role: `roles/set-pip-config`
  - Creates the file `/etc/pip.conf.d/system-break.conf` with the necessary pip configuration.
  - Includes tasks to verify and debug the presence of this file.
- Updated `playbooks/main.yml` to include this role under the `config` tag.

### Purpose:
Some modern Python environments (e.g. Python 3.10+) require the `--break-system-packages` option when installing with pip. This change ensures pip works correctly during automated installations and prevents related errors during Ansible runs.

Tested on Kali Linux with Python 3.13.
